### PR TITLE
Make PBW an optional dependency of cords

### DIFF
--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -1,4 +1,5 @@
-PREP(addGrassCutter);
-PREP(arsenalPBWFix);
 PREP(addChatCommands);
+PREP(addGrassCutter);
+PREP(areModsLoaded);
+PREP(arsenalPBWFix);
 PREP(parseNameToPlayer)

--- a/addons/common/functions/fnc_areModsLoaded.sqf
+++ b/addons/common/functions/fnc_areModsLoaded.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+/**
+ *  Author: Timi007
+ *
+ *  Description:
+ *     Checks if given mods (CfgPatches name) are loaded.
+ *
+ *  Parameter(s):
+ *      0: ARRAY - Mod names in CfgPatches.
+ *
+ *  Returns:
+ *      BOOLEAN - All mods are loaded.
+ *
+ *  Example:
+ *      [["mts_main"]] call mts_common_fnc_areModsLoaded
+ *      [["mts_main", "mts_common"]] call mts_common_fnc_areModsLoaded
+ *
+ */
+
+params [["_mods", [], [[]]]];
+
+CHECKRET(_mods isEqualTo [], false);
+
+(_mods findIf {!isClass (configFile >> "CfgPatches" >> _x)}) isEqualTo -1

--- a/addons/common/functions/fnc_arsenalPBWFix.sqf
+++ b/addons/common/functions/fnc_arsenalPBWFix.sqf
@@ -16,6 +16,6 @@
  *
  */
 
-CHECK(!isClass (configFile >> "CfgPatches" >> "PBW_German_Uniform") || !hasinterface);
+CHECK(![["PBW_German_Uniform"]] call FUNC(areModsLoaded) || !hasinterface);
 
 ["ace_arsenal_displayClosed", {execvm "german_common\scripts\ranks\getKlappen.sqf"}] call CBA_fnc_addEventhandler; //for gods sake execvm :(

--- a/addons/common/functions/fnc_arsenalPBWFix.sqf
+++ b/addons/common/functions/fnc_arsenalPBWFix.sqf
@@ -16,6 +16,6 @@
  *
  */
 
-CHECK(![["PBW_German_Uniform"]] call FUNC(areModsLoaded) || !hasinterface);
+CHECK(!([["PBW_German_Uniform"]] call FUNC(areModsLoaded)) || !hasinterface);
 
 ["ace_arsenal_displayClosed", {execvm "german_common\scripts\ranks\getKlappen.sqf"}] call CBA_fnc_addEventhandler; //for gods sake execvm :(

--- a/addons/cords/XEH_postInit.sqf
+++ b/addons/cords/XEH_postInit.sqf
@@ -1,4 +1,6 @@
 #include "script_component.hpp"
 
-call FUNC(addCordsToAce);
-call FUNC(addMajorToAce);
+if ([["PBW_German_Uniform", "PBW_German_Common"]] call EFUNC(commmon,areModsLoaded)) then {
+    call FUNC(addCordsToAce);
+    call FUNC(addMajorToAce);
+};

--- a/addons/cords/XEH_postInit.sqf
+++ b/addons/cords/XEH_postInit.sqf
@@ -1,6 +1,8 @@
 #include "script_component.hpp"
 
-if ([["PBW_German_Uniform", "PBW_German_Common"]] call EFUNC(commmon,areModsLoaded)) then {
+if (GVAR(PBWLoaded)) then {
+    INFO("PBW is loaded. Enabling ACE actions.");
+
     call FUNC(addCordsToAce);
     call FUNC(addMajorToAce);
 };

--- a/addons/cords/XEH_preInit.sqf
+++ b/addons/cords/XEH_preInit.sqf
@@ -6,6 +6,8 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+GVAR(PBWLoaded) = [["PBW_German_Uniform", "PBW_German_Common"]] call EFUNC(common,areModsLoaded);
+
 [
     QGVAR(enabled),
     "CHECKBOX",

--- a/addons/cords/config.cpp
+++ b/addons/cords/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"mts_main","PBW_German_Uniform","PBW_German_Common","ace_interact_menu"};
+        requiredAddons[] = {"mts_main","mts_common","ace_interact_menu"};
         author = "";
         authors[] = {"PhILoX","Timi007"};
         VERSION_CONFIG;

--- a/addons/cords/functions/fnc_addCordsToACE.sqf
+++ b/addons/cords/functions/fnc_addCordsToACE.sqf
@@ -34,7 +34,8 @@ private _infCordAction = [
     LLSTRING(inf),
     QPATHTOF(data\ui\mts_cords_ui_inf_co.paa),
     {
-        ["inf"] call FUNC(placeCordOnUniform);
+        params ["", "_player"];
+        [_player, "inf"] call FUNC(placeCordOnUniform);
     },
     _cordCondition
 ] call ace_interact_menu_fnc_createAction;
@@ -45,7 +46,8 @@ private _faCordAction = [
     LLSTRING(fa),
     QPATHTOF(data\ui\mts_cords_ui_fa_co.paa),
     {
-        ["inf_fa"] call FUNC(placeCordOnUniform);
+        params ["", "_player"];
+        [_player, "inf_fa"] call FUNC(placeCordOnUniform);
     },
     _cordCondition
 ] call ace_interact_menu_fnc_createAction;
@@ -56,7 +58,8 @@ private _oaCordAction = [
     LLSTRING(oa),
     QPATHTOF(data\ui\mts_cords_ui_oa_co.paa),
     {
-        ["inf_oa"] call FUNC(placeCordOnUniform);
+        params ["", "_player"];
+        [_player, "inf_oa"] call FUNC(placeCordOnUniform);
     },
     _cordCondition
 ] call ace_interact_menu_fnc_createAction;
@@ -67,7 +70,8 @@ private _pzCordAction = [
     LLSTRING(pz),
     QPATHTOF(data\ui\mts_cords_ui_pz_co.paa),
     {
-        ["pz"] call FUNC(placeCordOnUniform);
+        params ["", "_player"];
+        [_player, "pz"] call FUNC(placeCordOnUniform);
     },
     _cordCondition
 ] call ace_interact_menu_fnc_createAction;
@@ -78,7 +82,8 @@ private _pzFACordAction = [
     LLSTRING(fa),
     QPATHTOF(data\ui\mts_cords_ui_fa_co.paa),
     {
-        ["pz_fa"] call FUNC(placeCordOnUniform);
+        params ["", "_player"];
+        [_player, "pz_fa"] call FUNC(placeCordOnUniform);
     },
     _cordCondition
 ] call ace_interact_menu_fnc_createAction;
@@ -89,7 +94,8 @@ private _pzOACordAction = [
     LLSTRING(oa),
     QPATHTOF(data\ui\mts_cords_ui_oa_co.paa),
     {
-        ["pz_oa"] call FUNC(placeCordOnUniform);
+        params ["", "_player"];
+        [_player, "pz_oa"] call FUNC(placeCordOnUniform);
     },
     _cordCondition
 ] call ace_interact_menu_fnc_createAction;

--- a/addons/cords/functions/fnc_placeCordOnUniform.sqf
+++ b/addons/cords/functions/fnc_placeCordOnUniform.sqf
@@ -19,8 +19,7 @@
 
 params [["_player", objNull, [objNull]], ["_cordType", "", [""]]];
 
-CHECK(!([[ARR_2("PBW_German_Uniform", "PBW_German_Common")]] call EFUNC(common,areModsLoaded)));
-CHECK(isNull _player);
+CHECK(!GVAR(PBWLoaded) || isNull _player);
 
 private _camo = (uniform _player splitString "_") param [2, ""];
 

--- a/addons/cords/functions/fnc_placeCordOnUniform.sqf
+++ b/addons/cords/functions/fnc_placeCordOnUniform.sqf
@@ -19,7 +19,7 @@
 
 params [["_player", objNull, [objNull]], ["_cordType", "", [""]]];
 
-CHECK(![["PBW_German_Uniform", "PBW_German_Common"]] call EFUNC(common, areModsLoaded));
+CHECK(!([[ARR_2("PBW_German_Uniform", "PBW_German_Common")]] call EFUNC(common,areModsLoaded)));
 CHECK(isNull _player);
 
 private _camo = (uniform _player splitString "_") param [2, ""];

--- a/addons/cords/functions/fnc_placeCordOnUniform.sqf
+++ b/addons/cords/functions/fnc_placeCordOnUniform.sqf
@@ -6,33 +6,37 @@
  *      Places the given cord type on the uniform of the player.
  *
  *  Parameter(s):
- *      0: string - cord type
+ *      0: OBJECT - Player unit to place cord type on.
+ *      1: STRING - Cord type.
  *
  *  Returns:
  *      Nothing
  *
  *  Example:
- *      ["inf"] call mts_cords_fnc_placeCordOnUniform
+ *      [player, "inf"] call mts_cords_fnc_placeCordOnUniform
  *
  */
 
-params[["_cordType","",[""]]];
-private["_path"];
+params [["_player", objNull, [objNull]], ["_cordType", "", [""]]];
 
-private _camo = (uniform player splitString "_") param [2,""];
+CHECK(![["PBW_German_Uniform", "PBW_German_Common"]] call EFUNC(common, areModsLoaded));
+CHECK(isNull _player);
+
+private _camo = (uniform _player splitString "_") param [2, ""];
 
 CHECK(_cordType isEqualTo "" || _camo isEqualTo "");
 
-(_cordType splitString "_") params["_unit",["_cadet",""]];
+(_cordType splitString "_") params ["_unit", ["_cadet", ""]];
 
-if ((_cadet isEqualTo "fa") || (_cadet isEqualTo "oa")) then {
-    _path = format[QPATHTOF(data\cords\%1\%2\mts_cords_%1_%2_%3_co.paa), _unit, _camo, _cadet];
+private _path = "";
+if (_cadet isEqualTo "fa" || _cadet isEqualTo "oa") then {
+    _path = format [QPATHTOF(data\cords\%1\%2\mts_cords_%1_%2_%3_co.paa), _unit, _camo, _cadet];
 } else {
     if (_unit isEqualTo "inf") then {
-        _path = format["\german_uniforms\tex\pbw_schulterklappen%1_co.paa", _camo];
+        _path = format ["\german_uniforms\tex\pbw_schulterklappen%1_co.paa", _camo];
     } else {
-        _path = format[QPATHTOF(data\cords\%1\%2\mts_cords_%1_%2_co.paa), _unit, _camo];
+        _path = format [QPATHTOF(data\cords\%1\%2\mts_cords_%1_%2_co.paa), _unit, _camo];
     };
 };
 
-player setObjectTextureGlobal [2, _path];
+_player setObjectTextureGlobal [2, _path];


### PR DESCRIPTION
**When merged this pull request will:**
- Make PBW an optional dependency of cords (ACE actions are not created if PBW is not loaded)