### PR TITLE
Add need restart flag to settings

### DIFF
--- a/addons/common/functions/fnc_addBushCutter.sqf
+++ b/addons/common/functions/fnc_addBushCutter.sqf
@@ -16,7 +16,7 @@
  *
  */
 
-CHECK(!GVAR(bushcutter_enabled) || !hasinterface);
+CHECK(!hasinterface);
 
 private _action = [
     QGVAR(bushcutter),
@@ -45,8 +45,9 @@ private _action = [
     },
     {
         params ["", "_player"];
-        [_player, objNull] call ace_common_fnc_canInteractWith &&
-        {!isNull ([_player, BUSH_CUTTING_DISTANCE] call FUNC(seesBush))}
+        GVAR(bushcutter_enabled) &&
+        {!isNull ([_player, BUSH_CUTTING_DISTANCE] call FUNC(seesBush))} &&
+        {[_player, objNull] call ace_common_fnc_canInteractWith}
     }
 ] call ace_interact_menu_fnc_createAction;
 [(typeOf ACE_player), 1, ["ACE_SelfActions", "ACE_Equipment"], _action] call ace_interact_menu_fnc_addActionToClass;

--- a/addons/common/functions/fnc_addGrassCutter.sqf
+++ b/addons/common/functions/fnc_addGrassCutter.sqf
@@ -16,7 +16,7 @@
  *
  */
 
-CHECK(!GVAR(grasscutter_enabled) || !hasinterface);
+CHECK(!hasinterface);
 
 private _action = [
     QGVAR(grasscutter),
@@ -43,7 +43,8 @@ private _action = [
     },
     {
         params ["", "_player"];
-        [_player, objNull] call ace_common_fnc_canInteractWith
+        GVAR(grasscutter_enabled) &&
+        {[_player, objNull] call ace_common_fnc_canInteractWith}
     }
 ] call ace_interact_menu_fnc_createAction;
 [(typeOf ACE_player), 1, ["ACE_SelfActions", "ACE_Equipment"], _action] call ace_interact_menu_fnc_addActionToClass;

--- a/addons/common/initSettings.hpp
+++ b/addons/common/initSettings.hpp
@@ -12,7 +12,9 @@
     [LLSTRING(grasscutter), LLSTRING(grasscutter_tooltip)],
     [LELSTRING(main,category), LLSTRING(grasscutter_subCategory)],
     true,
-    0
+    0,
+    {},
+    true
 ] call CBA_fnc_addSetting;
 
 // Grasscutter: Size
@@ -47,7 +49,9 @@
     [LLSTRING(bushcutter), LLSTRING(bushcutter_tooltip)],
     [LELSTRING(main,category), LLSTRING(bushcutter_subCategory)],
     true,
-    0
+    0,
+    {},
+    true
 ] call CBA_fnc_addSetting;
 
 // Bushcutter: Time it takes to cut down a bush

--- a/addons/common/initSettings.hpp
+++ b/addons/common/initSettings.hpp
@@ -12,9 +12,7 @@
     [LLSTRING(grasscutter), LLSTRING(grasscutter_tooltip)],
     [LELSTRING(main,category), LLSTRING(grasscutter_subCategory)],
     true,
-    0,
-    {},
-    true
+    0
 ] call CBA_fnc_addSetting;
 
 // Grasscutter: Size
@@ -49,9 +47,7 @@
     [LLSTRING(bushcutter), LLSTRING(bushcutter_tooltip)],
     [LELSTRING(main,category), LLSTRING(bushcutter_subCategory)],
     true,
-    0,
-    {},
-    true
+    0
 ] call CBA_fnc_addSetting;
 
 // Bushcutter: Time it takes to cut down a bush

--- a/addons/cords/XEH_preInit.sqf
+++ b/addons/cords/XEH_preInit.sqf
@@ -15,7 +15,8 @@ GVAR(PBWLoaded) = [["PBW_German_Uniform", "PBW_German_Common"]] call EFUNC(commo
     [LELSTRING(main,category), LLSTRING(subCategory)],
     true,
     0,
-    {}
+    {},
+    true
 ] call CBA_fnc_addSetting;
 
 [
@@ -25,7 +26,8 @@ GVAR(PBWLoaded) = [["PBW_German_Uniform", "PBW_German_Common"]] call EFUNC(commo
     [LELSTRING(main,category), LLSTRING(subCategory)],
     "[""""]",
     1,
-    {}
+    {},
+    true
 ] call CBA_fnc_addSetting;
 
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Add need restart flag to settings (cord actions)
- Make grass/bush cutter enable action live-updating
