### PR TITLE
Armory - Fix player DB connection check and move initialization of module

### DIFF
--- a/addons/armory/XEH_postInit.sqf
+++ b/addons/armory/XEH_postInit.sqf
@@ -4,7 +4,7 @@
 
 TRACE_2("", isDedicated, GVAR(allowPlayerDBConnection));
 
-if (isDedicated || GVAR(allowPlayerDBConnection)) then {
+if (isDedicated || (isServer && GVAR(allowPlayerDBConnection))) then {
 
     private _dbConnected = ["armory", "armory.ini"] call DB_CONNECT;
     if (isNil "_dbConnected" || !(_dbConnected select 0)) exitWith {
@@ -33,6 +33,7 @@ if (isDedicated || GVAR(allowPlayerDBConnection)) then {
         };
     }] call CBA_fnc_addEventhandler;
 
+    LOG("Armory initialized");
     GVAR(initialized) =  true;
     publicVariable QGVAR(initialized);
 };

--- a/addons/armory/XEH_postInit.sqf
+++ b/addons/armory/XEH_postInit.sqf
@@ -1,6 +1,5 @@
 #include "script_component.hpp"
 
-GVAR(initialized) =  false;
 [QGVAR(updateArsenal), FUNC(updateArsenal)] call CBA_fnc_addEventHandler;
 
 TRACE_2("", isDedicated, GVAR(allowPlayerDBConnection));

--- a/addons/armory/XEH_preInit.sqf
+++ b/addons/armory/XEH_preInit.sqf
@@ -6,6 +6,7 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+GVAR(initialized) =  false;
 #include "initSettings.hpp"
 
 ADDON = true;

--- a/addons/armory/functions/fnc_createEquipment.sqf
+++ b/addons/armory/functions/fnc_createEquipment.sqf
@@ -26,7 +26,7 @@ if (_editors isEqualType "") then {
 };
 
 CHECK(!GVAR(initialized) || _equipmentName isEqualTo "" || ((_editors param [ARR_2(0,"")]) isEqualTo ""));
-CHECK(!isDedicated && !GVAR(allowPlayerDBConnection));
+CHECK(!isDedicated && !(isServer && GVAR(allowPlayerDBConnection)));
 
 [GVAR(sessionID), "insertEquipment", _equipmentName, _editors] call DB_SET;
 

--- a/addons/armory/functions/fnc_initEquipment.sqf
+++ b/addons/armory/functions/fnc_initEquipment.sqf
@@ -20,7 +20,7 @@ params [["_equipmentName", "", [""]]];
 TRACE_1("", _equipmentName);
 
 CHECKRET(!GVAR(initialized) || _equipmentName isEqualTo "",false);
-CHECKRET(!isDedicated && !GVAR(allowPlayerDBConnection),false);
+CHECKRET(!isDedicated && !(isServer && GVAR(allowPlayerDBConnection)),false);
 CHECKRET(_equipmentName in GVAR(equipmentInitialized),true);
 
 private _equipmentInfo = [GVAR(sessionID), "getEquipmentInfo", _equipmentName] call DB_GET;

--- a/addons/armory/functions/fnc_updateArsenal.sqf
+++ b/addons/armory/functions/fnc_updateArsenal.sqf
@@ -22,7 +22,7 @@ TRACE_3("", _equipmentName, _status, _argsSuccessfullyParsed);
 
 CHECK(!GVAR(initialized) || !_params);
 
-if (isDedicated || GVAR(allowPlayerDBConnection)) then {
+if (isDedicated || (isServer && GVAR(allowPlayerDBConnection))) then {
     private _equipmentArray = GVAR(equipment) getVariable [_equipmentName, []];
     private _equipmentID = _equipmentArray param [2, 0];
 

--- a/addons/armory/functions/fnc_updateBackpack.sqf
+++ b/addons/armory/functions/fnc_updateBackpack.sqf
@@ -30,7 +30,7 @@
 private _params = params [["_equipmentName", "", [""]], ["_name", "", [""]], ["_oldName", "", [""]]];
 
 CHECK(!GVAR(initialized) || !_params);
-CHECK(!isDedicated && !GVAR(allowPlayerDBConnection));
+CHECK(!isDedicated && !(isServer && GVAR(allowPlayerDBConnection)));
 
 (GVAR(equipment) getVariable [_equipmentName, []]) params ["", "_backpackNamespace", "", "_equipmentID"];
 _backpackNamespace getVariable [_name, []] params ["", "_idc", "_class", "_items"];

--- a/addons/armory/functions/fnc_updateEditors.sqf
+++ b/addons/armory/functions/fnc_updateEditors.sqf
@@ -35,7 +35,7 @@ private _checkEditors = false;
 } count _editors;
 
 CHECK(!GVAR(initialized) || !_params || _equipmentName isEqualTo "" || ((_editors param [ARR_2(0,"")]) isEqualTo "") || _checkEditors);
-CHECK(!isDedicated && !GVAR(allowPlayerDBConnection));
+CHECK(!isDedicated && !(isServer && GVAR(allowPlayerDBConnection)));
 
 private _equipmentArray = GVAR(equipment) getVariable [_equipmentName, []];
 private _equipmentID = _equipmentArray param [3, 0];

--- a/addons/armory/functions/fnc_updateLoadout.sqf
+++ b/addons/armory/functions/fnc_updateLoadout.sqf
@@ -30,7 +30,7 @@
 private _argsSuccessfullyParsed = params [["_equipmentName", "", [""]], ["_name", "", [""]], ["_oldName", "", [""]]];
 
 CHECK(!GVAR(initialized) || !_argsSuccessfullyParsed);
-CHECK(!isDedicated && !GVAR(allowPlayerDBConnection));
+CHECK(!isDedicated && !(isServer && GVAR(allowPlayerDBConnection)));
 
 (GVAR(equipment) getVariable [_equipmentName, []]) params ["_loadoutNamespace", "", "", "_equipmentID"];
 _loadoutNamespace getVariable [_name, []] params ["", "_idc", "_loadout", "_ace_medic", "_ace_engineer"];


### PR DESCRIPTION
**When merged this pull request will:**
- Prevents client from connecting to database if var allowPlayerDBConnection is true and player is on dedicated server
- Move initialization of mts_armory_initialized to preInit, so publicVariable can overwrite it while joining a server
